### PR TITLE
localproxy mode

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -25,7 +25,8 @@ module.exports = function () {
 
 /**
  * load the config from the network and merge with default config
- * @param options {target:save location and filename,keys: {key:,secret:},source:default loading target}
+ * @param options {target:save location and filename,keys: {key:,secret:},source:default loading target
+ *    localproxy: { name:,path:,target_url:}    }
  * @param callback function(err){}
  */
 Loader.prototype.get = function (options, callback) {
@@ -35,6 +36,7 @@ Loader.prototype.get = function (options, callback) {
   const keys = options.keys;
   const source = options.source;
   const io = this.io;
+  const localproxy = options.localproxy
 
   this.config = this.io.loadSync({source: source});
 
@@ -50,7 +52,13 @@ Loader.prototype.get = function (options, callback) {
     if(err){
       return callback(err);
     }
-    if (proxies && products ) {
+    if ( (proxies && products) || localproxy) {
+      if(localproxy){
+        proxies =  [ { apiProxyName: localproxy.name, revision: '1',
+                       proxyEndpoint: { name: 'default', basePath: localproxy.path },
+                       targetEndpoint: { name: 'default', url: localproxy.target_url } 
+                     } ]
+      }
       const mergedConfig = _merge(config, _mapEdgeProxies(proxies), _mapEdgeProducts(products));
       proxy_validator.validate(mergedConfig);
       _mergeKeys(mergedConfig, keys); // merge keys before sending to edge micro


### PR DESCRIPTION
I added localproxy support for micro sometime back - so it can run without having to pull config from edge. this was helpful when embedding microgateway as a sidecar container when deploying applications in containers [specifically w/ kubernetes], 
do you think this will be useful for mainstream micro usecases?

this is supposed to work with this PR - https://github.com/apigee-internal/microgateway/pull/61
