### PR TITLE
Getting rid of logging downloaded proxies, products, and jwt.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ node_modules
 .vscode
 .DS_Store
 .idea
-
+env.sh

--- a/lib/network.js
+++ b/lib/network.js
@@ -144,11 +144,8 @@ const _load = function (config, keys, callback) {
     }
     if (proxies.length === 0) {
       console.error('warning:', 'no edge micro proxies found in org');
-    } else {
-      console.info('downloaded proxies', util.inspect(proxies, {
-        colors: true
-      }));
-    }
+    } 
+
     var productInfo;
     try {
       productInfo = results[1] ? JSON.parse(results[1]) : {apiProduct: []};
@@ -167,19 +164,12 @@ const _load = function (config, keys, callback) {
     }
     if (products.length === 0) {
       console.error('warning:', 'no products found in org');
-    } else {
-      console.info('downloaded products', util.inspect(products, {
-        colors: true
-      }));
-    }
+    } 
+
     if (!config.oauth)
       config.oauth = {};
     if (results.length > 1 && results[2]) {
       config.oauth.public_key = results[2]; // save key in oauth section
-      console.info('downloaded jwt_public_key', util.inspect(config.oauth
-        .public_key, {
-        colors: true
-      }));
     } else {
       console.error('warning:', 'failed to download jwt_public_key');
     }

--- a/tests/it.js
+++ b/tests/it.js
@@ -26,10 +26,10 @@ describe('library basic functions', function () {
   });
   it('index loads from server', function (done) {
     var keys = {
-      key: "ae686bcfe929f2392c8e13dffa3b46b815216fe64ac1b43e2868b3f74878c2a1",
-      secret: "4ee8bc8463729df390e60587748a67b33b84d309143438aa98dcf4f259f38832"
+      key: process.env.EDGEMICRO_KEY,
+      secret: process.env.EDGEMICRO_SECRET
     }
-    configlib.get({source:'./tests/config.yaml',target:getPath,keys:keys}, function (err,config) {
+    configlib.get({source:'./tests/ws-poc3-test-config.yaml',target:getPath,keys:keys}, function (err,config) {
       assert(config, 'does not have config')
       done();
     });

--- a/tests/ws-poc3-test-config.yaml
+++ b/tests/ws-poc3-test-config.yaml
@@ -1,0 +1,40 @@
+edge_config:
+  bootstrap: >-
+    https://edgemicroservices-us-east-1.apigee.net/edgemicro/bootstrap/organization/ws-poc3/environment/test
+  jwt_public_key: 'https://ws-poc3-test.apigee.net/edgemicro-auth/publicKey'
+  managementUri: 'https://api.enterprise.apigee.com'
+  vaultName: microgateway
+  authUri: 'https://%s-%s.apigee.net/edgemicro-auth'
+  baseUri: >-
+    https://edgemicroservices.apigee.net/edgemicro/%s/organization/%s/environment/%s
+  bootstrapMessage: Please copy the following property to the edge micro agent config
+  keySecretMessage: The following credentials are required to start edge micro
+  products: 'https://ws-poc3-test.apigee.net/edgemicro-auth/products'
+edgemicro:
+  port: 8000
+  max_connections: 1000
+  max_connections_hard: 5000
+  restart_sleep: 500
+  restart_max: 50
+  max_times: 300
+  logging:
+    to_console: true
+    level: error
+    dir: /var/tmp
+    stats_log_interval: 60
+    rotate_interval: 24
+  plugins:
+    sequence: null
+headers:
+  x-forwarded-for: true
+  x-forwarded-host: true
+  x-request-id: true
+  x-response-time: true
+  via: true
+oauth:
+  allowNoAuthorization: false
+  allowInvalidAuthorization: false
+  verify_api_key_url: 'https://ws-poc3-test.apigee.net/edgemicro-auth/verifyApiKey'
+analytics:
+  uri: >-
+    https://edgemicroservices-us-east-1.apigee.net/edgemicro/axpublisher/organization/ws-poc3/environment/test


### PR DESCRIPTION
Rejoice! I have gotten rid of the extraneous unnecessary pernicious logging of downloaded proxies, products, and the JWT token from the default logging.

For now the information can still be logged out with a `DEBUG=*` because it's logged out somewhere else. I'm not sure if we want to remove it or not.

Thoughts @F1ERRO?