### PR TITLE
Xapid 787

### DIFF
--- a/lib/apid.js
+++ b/lib/apid.js
@@ -78,14 +78,14 @@ Apid.prototype.get = function (options, callback) {
             if(response.statusCode == 200) {
               self.etagValue = response.headers['etag'];
 
-              var systemConfig;
+              self.systemConfig = {};
               try {
-                systemConfig = yaml.safeLoad(fs.readFileSync(options.systemConfigPath));
+                self.systemConfig = yaml.safeLoad(fs.readFileSync(options.systemConfigPath));
               } catch(e) {
                 return callback(e);
               }
               
-              newConfig = Object.assign(newConfig, systemConfig);
+              newConfig = Object.assign(newConfig, self.systemConfig);
               
               self.deploymentIds = currentDeploymentIds;
               self.deploymentIds.forEach((deploymentId) => {
@@ -128,7 +128,10 @@ Apid.prototype.beginLongPoll = function(clientSocket, pollInterval, retry) {
             console.log("No change from apid reported.  Will retry...");
             self.beginLongPoll(clientSocket, pollInterval, retry);
         } else {
+            self.etagValue = response.headers['etag'];
+            
             var parsedBody = JSON.parse(body);
+
             var currentDeploymentIds = parsedBody.map((bundleConfig) => {
               return bundleConfig.id;
             })
@@ -176,6 +179,10 @@ Apid.prototype.beginLongPoll = function(clientSocket, pollInterval, retry) {
                   return console.error(util.format('error: Error getting deployments for gateway: %s not restarting.', err.message))
                 }
           
+                
+                //Need to assign system config values
+                newConfig = Object.assign(newConfig, self.systemConfig);
+
                 //If there wasn't an error, and we have a good config let's restart edgemicro
                 process.env.CONFIG = JSON.stringify(newConfig);
                 clientSocket.sendMessage({command: 'reload'});

--- a/lib/apid.js
+++ b/lib/apid.js
@@ -33,6 +33,7 @@ Apid.prototype.get = function (options, callback) {
     var self = this;
     this.apidEndpoint = options.apidEndpoint;
     this.printRawConfig = options.printRawConfig || false;
+    this.apidPort = options.port || 0;
 
     if(options.configFile) {
       try {
@@ -85,8 +86,14 @@ Apid.prototype.get = function (options, callback) {
                 return callback(e);
               }
               
+              if(self.apidPort) {
+                self.systemConfig.system.port = parseInt(self.apidPort);
+              }
+
               newConfig = Object.assign(newConfig, self.systemConfig);
               
+              
+
               self.deploymentIds = currentDeploymentIds;
               self.deploymentIds.forEach((deploymentId) => {
                 var reportObject = self._createSuccess(deploymentId);

--- a/tests/deployments_current.js
+++ b/tests/deployments_current.js
@@ -255,7 +255,6 @@ describe('long polling errors', () => {
 
         request.on('end', () => {
           var body = JSON.parse(buf.toString());
-          console.log(body);
           if(count == 1) {
             assert.equal(body.length, 4);
             body.forEach((status) => {
@@ -364,6 +363,7 @@ describe('long polling full replace', () => {
       var mockClientSocket = {
         sendMessage: function(message) {
           var config = JSON.parse(process.env.CONFIG);
+          assert.equal(config.system.port, 8000);
           assert.equal(config.proxies.length, 4);
           var scopes = Object.keys(config.scopes);
           assert.equal(scopes.length, 2);


### PR DESCRIPTION
Fixing XAPID-787

This caches system config information in memory, and we reapply it when receiving a reload instruction.