### PR TITLE
Config quota buffer size

### DIFF
--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -98,5 +98,20 @@ module.exports.validate = function validate(config) {
     assert(typeof config.oauth.allowNoAuthorization === 'boolean', 'config.oauth.allowNoAuthorization is not defined');
     assert(typeof config.oauth.allowInvalidAuthorization === 'boolean', 'config.oauth.allowInvalidAuthorization is not defined');
   }
+  if (config.quotas) {
+    assert(typeof config.quotas === 'object', 'config.quotas is not an object');
+    Object.keys(config.quotas).forEach(timeUnit => {
+        assert(timeUnit === 'default' ||
+            timeUnit === 'hour' ||
+            timeUnit === 'minute' ||
+            timeUnit === 'day' ||
+            timeUnit === 'week', 'invalid value in config.quotas: ' + timeUnit +
+                ', valid values are hour, minute, day, week, & default');
+        let quotaSpec = config.quotas[timeUnit]
+        assert(typeof quotaSpec === 'object', 'config.quotas.' + timeUnit + ' is not an object');
+        assert(typeof quotaSpec.bufferSize === 'number', 'config.quotas.' + timeUnit + '.bufferSize is not a number');
+        assert(+quotaSpec.bufferSize > 0, 'config.quotas.' + timeUnit + '.bufferSize must be greater than zero');
+    })  
+  }
   return config;
 };

--- a/lib/network.js
+++ b/lib/network.js
@@ -173,7 +173,7 @@ function loadConfiguration(thisconfig, keys, callback) {
                 }
             }
 
-            const mergedConfig = _merge(config, _mapEdgeProxies(proxies), _mapEdgeProducts(products));
+            const mergedConfig = _merge(config, _mapEdgeProxies(proxies), _mapEdgeProducts(products, config));
             proxy_validator.validate(mergedConfig);
             _mergeKeys(mergedConfig, keys); // merge keys before sending to edge micro
             callback(null, mergedConfig);
@@ -579,7 +579,7 @@ const _mapEdgeProxies = function(proxies) {
     return mappedProxies;
 }
 // note: path_to_proxy as written below is broken, one product path can have multiple proxies
-const _mapEdgeProducts = function(products) {
+const _mapEdgeProducts = function(products, config) {
     //const path_to_proxy = {};
     const product_to_quota = {};
     const product_to_proxy = {};
@@ -596,11 +596,12 @@ const _mapEdgeProducts = function(products) {
                 product_to_proxy[product.name] = [proxy];
             }
             if (product.quota) {
+                let quotasSpec = config.quotas[product.quotaTimeUnit] || config.quotas['default']
                 product_to_quota[product.name] = {
                     allow: product.quota,
                     interval: product.quotaInterval,
                     timeUnit: product.quotaTimeUnit,
-                    bufferSize: 10000
+                    bufferSize: quotasSpec.bufferSize,
                 };
             }
         });
@@ -642,7 +643,12 @@ function _setDefaults(config) {
             // NOTE: This remains 250 for backwards compatibility. In practice, this should
             // likely be defined to be a longer interval in the user config file.
             flushInterval: 250
-        }
+        },
+        quotas: {
+            default: {
+                bufferSize: 10000,
+            },
+        },
     };
 
     // merge config, overriding defaults with user-defined config values

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "microgateway-config",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "microgateway-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1363,9 +1363,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fs-extra": "^0.26.7",
     "js-yaml": "^3.5.4",
     "jshint-stylish": "^2.2.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.15",
     "request": "^2.87.0",
     "resolve": "^1.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microgateway-config",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Apigee Microgateway Handler",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/tests/defaultValidator.unit.test.js
+++ b/tests/defaultValidator.unit.test.js
@@ -66,4 +66,60 @@ describe('default-validator module', () => {
             done();
         };
     });
+
+    it('throws error for invalid quotas type', (done) => {
+        const quotas = Object.assign({}, loadedConfig, { quotas: 2})
+        try {
+            defaultValidator.validate(quotas);
+        } catch (err) {
+            assert(err.message.includes('config.quotas is not an object'));
+        }
+        done();
+    });
+
+    it('throws error for invalid quotas key', (done) => {
+        const quotas = Object.assign({}, loadedConfig, { quotas: { invalid: {}}})
+        try {
+            defaultValidator.validate(quotas);
+        } catch (err) {
+            assert(err.message.includes('invalid value in config.quotas'));
+        }
+        done();
+    });
+
+    it('throws error for missing quotas bufferSize', (done) => {
+        const quotas = Object.assign({}, loadedConfig, { quotas: { default: { }}})
+        try {
+            defaultValidator.validate(quotas);
+        } catch (err) {
+            assert(err.message.includes('default.bufferSize is not a number'));
+        }
+        done();
+    });
+
+    it('throws error for non-number bufferSize', (done) => {
+        const quotas = Object.assign({}, loadedConfig, { quotas: { default: { bufferSize: 'over9000' }}})
+        try {
+            defaultValidator.validate(quotas);
+        } catch (err) {
+            assert(err.message.includes('default.bufferSize is not a number'));
+        }
+        done();
+    });
+
+    it('throws error for invalid quotas bufferSize', (done) => {
+        const quotas = Object.assign({}, loadedConfig, { quotas: { default: { bufferSize: -1 }}})
+        try {
+            defaultValidator.validate(quotas);
+        } catch (err) {
+            assert(err.message.includes('default.bufferSize must be greater than zero'));
+        }
+        done();
+    });
+
+    it('accepts a valid quota bufferSize', (done) => {
+        const quotas = Object.assign({}, loadedConfig, { quotas: { minute: { bufferSize: 1 }}})
+        defaultValidator.validate(quotas);
+        done();
+    });
 });

--- a/tests/fixtures/load-victorshaw-eval-test-config.yaml
+++ b/tests/fixtures/load-victorshaw-eval-test-config.yaml
@@ -38,3 +38,8 @@ analytics:
   bufferSize: 10000
   batchSize: 500
   flushInterval: 5000
+quotas:
+  minute:
+    bufferSize: 10
+  default:
+    bufferSize: 10000


### PR DESCRIPTION
Allows specification of quotas bufferSize based on timeUnit. Each quota timeUnit may have a separate config and a default may be set for those that do not. See [example config](https://github.com/apigee/microgateway-config/blob/02cc287f36eb16a1bb49cbbfde83ea48b31011d9/tests/fixtures/load-victorshaw-eval-test-config.yaml#L41).