### PR TITLE
for306 140090623 Use quotaUri for products if available

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -12,6 +12,7 @@ const proxy_validator = require('./proxy-validator');
 const debug = debug_('agent:config');
 const ioLib = require('./io');
 const fs = require('fs');
+const util = require('util');
 
 let writeConsoleLog = function () {};
 const CONSOLE_LOG_TAG_COMP = 'microgateway-config network';
@@ -32,6 +33,7 @@ module.exports = function() {
 
 var proxyPattern;
 var proxies = null;
+let globalOptions = null;
 
 /**
  * load the config from the network and merge with default config
@@ -42,6 +44,7 @@ var proxies = null;
 Loader.prototype.get = function(options, callback) {
 
 
+    globalOptions = options;
     //EDGEMICRO_LOCAL - allows microgateway to function without any connection to Apigee Edge
     if (process.env.EDGEMICRO_LOCAL === "1") {
         debug("running microgateway in local mode");
@@ -534,7 +537,12 @@ const _merge = function(config, proxies, products) {
     mergedConfig['product_to_api_resource'] = products.product_to_api_resource;
     mergedConfig['quota'] = products.product_to_quota;
     if (mergedConfig['quota']) {
-        const uri = updates.edge_config.bootstrap.replace('bootstrap', 'quotas');
+        let uri = '';
+        if(updates.edge_config.quotaUri) {
+            uri = util.format(config.edge_config.quotaUri, globalOptions.org, globalOptions.env);
+        } else {
+            uri = updates.edge_config.bootstrap.replace('bootstrap', 'quotas');
+        }
         Object.keys(mergedConfig['quota']).forEach(function(name) {
             mergedConfig['quota'][name].uri = uri;
         });


### PR DESCRIPTION
Use quotaUri if configured in yaml config and otherwise use bootstrap.
The quotaUri will be used by quota plugin to apply quota.
eg of yaml config:
quotaUri: https://%s-%s.apigee.net/edgemicro-auth
Where %s %s = org env