### PR TITLE
For309 add failopen to quota

### DIFF
--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -103,6 +103,8 @@ module.exports.validate = function validate(config) {
     Object.keys(config.quotas).forEach(key => {
       if (  key === 'failOpen') {
         assert(typeof config.quotas[key] === 'boolean', 'config.quotas.' + key + ' is not an boolean');
+      } else if (  key === 'useDebugMpId') {
+        assert(typeof config.quotas[key] === 'boolean', 'config.quotas.' + key + ' is not an boolean');
       } else{
         let timeUnit = key;
         assert(timeUnit === 'default' ||

--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -100,7 +100,11 @@ module.exports.validate = function validate(config) {
   }
   if (config.quotas) {
     assert(typeof config.quotas === 'object', 'config.quotas is not an object');
-    Object.keys(config.quotas).forEach(timeUnit => {
+    Object.keys(config.quotas).forEach(key => {
+      if (  key === 'failOpen') {
+        assert(typeof config.quotas[key] === 'boolean', 'config.quotas.' + key + ' is not an boolean');
+      } else{
+        let timeUnit = key;
         assert(timeUnit === 'default' ||
             timeUnit === 'hour' ||
             timeUnit === 'minute' ||
@@ -111,6 +115,7 @@ module.exports.validate = function validate(config) {
         assert(typeof quotaSpec === 'object', 'config.quotas.' + timeUnit + ' is not an object');
         assert(typeof quotaSpec.bufferSize === 'number', 'config.quotas.' + timeUnit + '.bufferSize is not a number');
         assert(+quotaSpec.bufferSize >= 0, 'config.quotas.' + timeUnit + '.bufferSize must be greater than or equal to zero');
+      }
     })  
   }
   return config;

--- a/lib/network.js
+++ b/lib/network.js
@@ -612,7 +612,8 @@ const _mapEdgeProducts = function(products, config) {
                     interval: product.quotaInterval,
                     timeUnit: product.quotaTimeUnit,
                     bufferSize: quotasSpec.bufferSize,
-                    failOpen: config.quotas.hasOwnProperty('failOpen') ? config.quotas.failOpen : false
+                    failOpen: config.quotas.hasOwnProperty('failOpen') ? config.quotas.failOpen : false,
+                    useDebugMpId: config.quotas.hasOwnProperty('useDebugMpId') ? config.quotas.useDebugMpId : false,
                 };
             }
         });

--- a/lib/network.js
+++ b/lib/network.js
@@ -612,6 +612,7 @@ const _mapEdgeProducts = function(products, config) {
                     interval: product.quotaInterval,
                     timeUnit: product.quotaTimeUnit,
                     bufferSize: quotasSpec.bufferSize,
+                    failOpen: config.quotas.hasOwnProperty('failOpen') ? config.quotas.failOpen : false
                 };
             }
         });


### PR DESCRIPTION
1. Add **failOpen** config to quotas.
Will be used in quota failure case if set true, in this case 'quota-failed-open' flag will be added to request object.To use this feature set 'failOpen: true' to quotas in your yaml config, Below is an example:
quotas:
  failOpen: true

2. Add **useDebugMpId** config to quotas
If set to true quota call to edge apply will add **"debugMpId":true** to request body.
To use this feature set 'useDebugMpId: true' to 'quotas' in your yaml config, Below is an example:
quotas:
  useDebugMpId: true