### PR TITLE
Add redis configs to quotas

### DIFF
--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -105,6 +105,14 @@ module.exports.validate = function validate(config) {
         assert(typeof config.quotas[key] === 'boolean', 'config.quotas.' + key + ' is not an boolean');
       } else if (  key === 'useDebugMpId') {
         assert(typeof config.quotas[key] === 'boolean', 'config.quotas.' + key + ' is not an boolean');
+      } else if (  key === 'useRedis') {
+        assert(typeof config.quotas[key] === 'boolean', 'config.quotas.' + key + ' is not an boolean');
+      } else if (  key === 'redisHost') {
+        assert(typeof config.quotas[key] === 'string', 'config.quotas.' + key + ' is not an boolean');
+      } else if (  key === 'redisPort') {
+        assert(typeof config.quotas[key] === 'number', 'config.quotas.' + key + ' is not an boolean');
+      } else if (  key === 'redisDb') {
+        assert( ( typeof config.quotas[key] === 'number' || typeof config.quotas[key] === 'string'), 'config.quotas.' + key + ' is not an boolean');
       } else{
         let timeUnit = key;
         assert(timeUnit === 'default' ||

--- a/lib/network.js
+++ b/lib/network.js
@@ -614,7 +614,18 @@ const _mapEdgeProducts = function(products, config) {
                     bufferSize: quotasSpec.bufferSize,
                     failOpen: config.quotas.hasOwnProperty('failOpen') ? config.quotas.failOpen : false,
                     useDebugMpId: config.quotas.hasOwnProperty('useDebugMpId') ? config.quotas.useDebugMpId : false,
+                    useRedis: config.quotas.hasOwnProperty('useRedis') ? config.quotas.useRedis : false,
                 };
+                
+                if (config.quotas.hasOwnProperty('redisHost')) {
+                    product_to_quota[product.name]['host'] = config.quotas.redisHost;
+                }
+                if (config.quotas.hasOwnProperty('redisPort')) {
+                    product_to_quota[product.name]['port'] = config.quotas.redisPort;
+                }
+                if (config.quotas.hasOwnProperty('redisDb')) {
+                    product_to_quota[product.name]['db'] = config.quotas.redisDb;
+                }
             }
         });
     });


### PR DESCRIPTION
Add configs to allow usage of redis quota in quota plugin.
If 'useRedis' is true then 'volos-quota-redis' will be used else 'volos-quota-apigee' will be used.
Below is an example of config

quotas:
  useRedis: true
  redisHost: localhost
  redisPort: 6379
  redisDb: 1