### PR TITLE
143740696 Restructure quotas bufferSize configuration.

### DIFF
--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -56,8 +56,9 @@ module.exports.validate = function validate(config) {
     assert(config.quota.timeUnit === 'hour' ||
       config.quota.timeUnit === 'minute' ||
       config.quota.timeUnit === 'day' ||
-      config.quota.timeUnit === 'week', 'invalid value for config.quota.timeUnit: ' + config.quota.timeUnit +
-      ', valid values are hour, minute, day & week');
+      config.quota.timeUnit === 'week'||
+      config.quota.timeUnit === 'month', 'invalid value for config.quota.timeUnit: ' + config.quota.timeUnit +
+      ', valid values are hour, minute, day, week & month');
     assert(config.quota.interval, 'config.quota.interval is not defined');
     assert(typeof config.quota.interval === 'number', 'config.quota.interval is not a number');
     var interval_message = 'invalid value for config.quota.interval: ' + config.quota.interval;
@@ -108,11 +109,11 @@ module.exports.validate = function validate(config) {
       } else if (  key === 'useRedis') {
         assert(typeof config.quotas[key] === 'boolean', 'config.quotas.' + key + ' is not an boolean');
       } else if (  key === 'redisHost') {
-        assert(typeof config.quotas[key] === 'string', 'config.quotas.' + key + ' is not an boolean');
+        assert(typeof config.quotas[key] === 'string', 'config.quotas.' + key + ' is not an string');
       } else if (  key === 'redisPort') {
-        assert(typeof config.quotas[key] === 'number', 'config.quotas.' + key + ' is not an boolean');
+        assert(typeof config.quotas[key] === 'number', 'config.quotas.' + key + ' is not an number');
       } else if (  key === 'redisDb') {
-        assert( ( typeof config.quotas[key] === 'number' || typeof config.quotas[key] === 'string'), 'config.quotas.' + key + ' is not an boolean');
+        assert(typeof config.quotas[key] === 'number', 'config.quotas.' + key + ' is not an number');
       } else if (  key === 'bufferSize'){
         let quotaSpec = config.quotas[key];
         assert(typeof quotaSpec === 'object', 'config.quotas.' + key + ' is not an object');
@@ -121,8 +122,9 @@ module.exports.validate = function validate(config) {
           timeUnit === 'hour' ||
           timeUnit === 'minute' ||
           timeUnit === 'day' ||
-          timeUnit === 'week', 'invalid value in config.quotas.bufferSize: ' + timeUnit +
-              ', valid values are hour, minute, day, week, & default');
+          timeUnit === 'week'||
+          timeUnit === 'month', 'invalid value in config.quotas.bufferSize: ' + timeUnit +
+              ', valid values are hour, minute, day, week, month & default');
           let bufferSize = config.quotas.bufferSize[timeUnit];
           assert(typeof bufferSize === 'number', 'config.quotas.bufferSize.' + timeUnit + ' is not a number');
           assert(+bufferSize >= 0, 'config.quotas.bufferSize.' + timeUnit + ' must be greater than or equal to zero');

--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -113,18 +113,20 @@ module.exports.validate = function validate(config) {
         assert(typeof config.quotas[key] === 'number', 'config.quotas.' + key + ' is not an boolean');
       } else if (  key === 'redisDb') {
         assert( ( typeof config.quotas[key] === 'number' || typeof config.quotas[key] === 'string'), 'config.quotas.' + key + ' is not an boolean');
-      } else{
-        let timeUnit = key;
-        assert(timeUnit === 'default' ||
-            timeUnit === 'hour' ||
-            timeUnit === 'minute' ||
-            timeUnit === 'day' ||
-            timeUnit === 'week', 'invalid value in config.quotas: ' + timeUnit +
-                ', valid values are hour, minute, day, week, & default');
-        let quotaSpec = config.quotas[timeUnit]
-        assert(typeof quotaSpec === 'object', 'config.quotas.' + timeUnit + ' is not an object');
-        assert(typeof quotaSpec.bufferSize === 'number', 'config.quotas.' + timeUnit + '.bufferSize is not a number');
-        assert(+quotaSpec.bufferSize >= 0, 'config.quotas.' + timeUnit + '.bufferSize must be greater than or equal to zero');
+      } else if (  key === 'bufferSize'){
+        let quotaSpec = config.quotas[key];
+        assert(typeof quotaSpec === 'object', 'config.quotas.' + key + ' is not an object');
+        Object.keys(quotaSpec).forEach(timeUnit => {
+          assert(timeUnit === 'default' ||
+          timeUnit === 'hour' ||
+          timeUnit === 'minute' ||
+          timeUnit === 'day' ||
+          timeUnit === 'week', 'invalid value in config.quotas.bufferSize: ' + timeUnit +
+              ', valid values are hour, minute, day, week, & default');
+          let bufferSize = config.quotas.bufferSize[timeUnit];
+          assert(typeof bufferSize === 'number', 'config.quotas.bufferSize.' + timeUnit + ' is not a number');
+          assert(+bufferSize >= 0, 'config.quotas.bufferSize.' + timeUnit + ' must be greater than or equal to zero');
+        });
       }
     })  
   }

--- a/lib/network.js
+++ b/lib/network.js
@@ -606,12 +606,12 @@ const _mapEdgeProducts = function(products, config) {
                 product_to_proxy[product.name] = [proxy];
             }
             if (product.quota) {
-                let quotasSpec = config.quotas[product.quotaTimeUnit] || config.quotas['default']
+                let bufferSize = config.quotas.bufferSize[product.quotaTimeUnit] || config.quotas.bufferSize['default']
                 product_to_quota[product.name] = {
                     allow: product.quota,
                     interval: product.quotaInterval,
                     timeUnit: product.quotaTimeUnit,
-                    bufferSize: quotasSpec.bufferSize,
+                    bufferSize: bufferSize,
                     failOpen: config.quotas.hasOwnProperty('failOpen') ? config.quotas.failOpen : false,
                     useDebugMpId: config.quotas.hasOwnProperty('useDebugMpId') ? config.quotas.useDebugMpId : false,
                     useRedis: config.quotas.hasOwnProperty('useRedis') ? config.quotas.useRedis : false,
@@ -668,8 +668,8 @@ function _setDefaults(config) {
             flushInterval: 250
         },
         quotas: {
-            default: {
-                bufferSize: 10000,
+            bufferSize: {
+                default: 10000,
             },
         },
     };


### PR DESCRIPTION
Change quotas.timeUnit.bufferSize to quotas.bufferSize.timeUnit to make it more readable.

Below is an example for new configuration:

quotas:
  bufferSize:
    default: 2000
    minute: 1000
    hour: 100000