### PR TITLE
151285018 Add validations to edgemicro.proxy

### DIFF
--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -19,21 +19,71 @@ module.exports.validate = function validate(config) {
         assert(config.edge_config.refresh_interval >= 3600000, 'config.edge_config.refresh_interval is too small (min 1h)');
       }
     }
-    if (config.edge_config.proxy) {
-      var proxy_url = url.parse(config.edge_config.proxy);
-      assert(proxy_url.protocol === 'http:' || proxy_url.protocol === 'https:', 'invalid protocol for config.edge_config.proxy (expected http: or https:): ' + proxy_url.protocol);
-      assert(proxy_url.hostname, 'invalid proxy host for config.edge_config.proxy: ' + proxy_url.hostname);
-    }
-    if (typeof config.edge_config.proxy_tunnel !== 'undefined') {
-      assert(typeof config.edge_config.proxy_tunnel === 'boolean', 'config.edge_config.proxy_tunnel is not a boolean');
-      var httpProxyEnvVariables = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'];
-      let proxy;
-      httpProxyEnvVariables.forEach((v)=> {
-        if(process.env[v]) {
-          proxy = process.env[v];
+    
+    if ( config.edgemicro.proxy ) {
+
+      if (typeof config.edgemicro.proxy.enabled !== 'undefined') {
+        assert(typeof config.edgemicro.proxy.enabled === 'boolean', 'config.edgemicro.proxy.tunnel is not a boolean');
+        if ( config.edgemicro.proxy.enabled === true ) {
+          var httpProxyEnvVariables = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'];
+          let proxy = config.edgemicro.proxy.url;
+          if ( !proxy ) {
+            httpProxyEnvVariables.forEach((v)=> {
+              if(process.env[v]) {
+                proxy = process.env[v];
+              }
+            });
+          }
+          assert(typeof proxy !== 'undefined',
+          'proxy must be defined using edgemicro.proxy.url or environment variable HTTP_PROXY/http_proxy, if config.edgemicro.proxy.enabled is true');
         }
-      });
-      assert(typeof proxy !== 'undefined', 'proxy must be defined using environment variable HTTP_PROXY/http_proxy, if config.edge_config.proxy_tunnel is defined');
+      }
+      if ( config.edgemicro.proxy.enabled === true ) {
+        
+        if (typeof config.edgemicro.proxy.tunnel !== 'undefined') {
+          assert(typeof config.edgemicro.proxy.tunnel === 'boolean', 'config.edgemicro.proxy.tunnel is not a boolean');
+          var httpProxyEnvVariables = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'];
+          let proxy = config.edgemicro.proxy.url;
+          if ( !proxy ) {
+            httpProxyEnvVariables.forEach((v)=> {
+              if(process.env[v]) {
+                proxy = process.env[v];
+              }
+            });
+          }
+          assert(typeof proxy !== 'undefined',
+          'proxy must be defined using edgemicro.proxy.url or environment variable HTTP_PROXY/http_proxy, if config.edgemicro.proxy.tunnel is defined');
+          assert( ( typeof config.edgemicro.proxy.enabled !== 'undefined' && config.edgemicro.proxy.enabled === true),
+          'edgemicro.proxy.enabled must be true, if config.edgemicro.proxy.tunnel is defined');
+        }
+  
+       
+        if (config.edgemicro.proxy.url) {
+          assert( ( typeof config.edgemicro.proxy.enabled !== 'undefined' && config.edgemicro.proxy.enabled === true),
+          'edgemicro.proxy.enabled must be true, if config.edgemicro.proxy.tunnel is defined');
+          var proxy_url = url.parse(config.edgemicro.proxy.url);
+          assert(proxy_url.protocol === 'http:' || proxy_url.protocol === 'https:', 'invalid protocol for config.edgemicro.proxy.url (expected http: or https:): ' + proxy_url.protocol);
+          assert(proxy_url.hostname, 'invalid proxy host for config.edgemicro.proxy.url: ' + proxy_url.hostname);
+        }
+  
+        if (config.edgemicro.proxy.bypass) {
+          assert( ( typeof config.edgemicro.proxy.enabled !== 'undefined' && config.edgemicro.proxy.enabled === true),
+          'edgemicro.proxy.enabled must be true, if config.edgemicro.proxy.tunnel is defined');
+          let httpProxyEnvVariables = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'];
+          let proxy = config.edgemicro.proxy.url;
+          if ( !proxy ) {
+            httpProxyEnvVariables.forEach((v)=> {
+              if(process.env[v]) {
+                proxy = process.env[v];
+              }
+            });
+          }
+          assert(typeof proxy !== 'undefined',
+          'proxy must be defined using edgemicro.proxy.url or environment variable HTTP_PROXY/http_proxy, if config.edgemicro.proxy.tunnel is defined');
+        }
+      }
+      
+
     }
     if (config.edge_config.hasOwnProperty('redisBasedConfigCache')) {
       assert(typeof config.edge_config.redisBasedConfigCache === 'boolean', 'config.edge_config.redisBasedConfigCache is not a boolean');

--- a/lib/network.js
+++ b/lib/network.js
@@ -283,12 +283,7 @@ function validateJSON(data){
 const processLoad = (config, keys, callback, useSynchronizer, redisClient) => {
 
     const options = {};
-    if (config.edge_config.proxy) {
-        options['proxy'] = config.edge_config.proxy;
-    }
-    if (typeof config.edge_config.proxy_tunnel !== 'undefined') {
-        options['tunnel'] = config.edge_config.proxy_tunnel;
-    }
+
     if (typeof config.edge_config.proxyPattern !== 'undefined') {
         proxyPattern = config.edge_config.proxyPattern;
     }
@@ -812,13 +807,7 @@ function _setDefaults(config) {
 
     // merge config, overriding defaults with user-defined config values
     var merged = _.merge({}, defaults, config);
-
-    // propagate proxy configuration to the edgemicro section for use by edgemicro
-    if (merged.edge_config.proxy) {
-        merged.edgemicro.proxy = merged.edge_config.proxy;
-        merged.edgemicro.proxy_tunnel = merged.edge_config.proxy_tunnel;
-    }
-
+   
     return merged;
 }
 


### PR DESCRIPTION
Add validations on below configs:

edgemicro:
  proxy:
    tunnel: true
    url: 'http://192.168.2.178:3128'
    bypass: 'localhost' # target domains to bypass the proxy.
    enabled: true

‘enabled’ is boolean and if set to ’true’, here the ’url’ must be defined or
the env variables HTTP_PROXY/http_proxy or HTTPS_PROXY/https_proxy must be set.

If ‘url | bypass | tunnel’ is defined here, ‘enabled’ must be set to ‘true’.

Remove the configs ‘edge_config.proxy’ and ‘edge_config.proxy_tunnel’.