### PR TITLE
152005003 Add org and env to config

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -665,6 +665,12 @@ const _merge = function(config, proxies, products) {
             mergedConfig['quota'][name].uri = uri;
         });
     }
+
+    mergedConfig.edgemicro['global'] = {
+        org: globalOptions.org, 
+        env: globalOptions.env
+    }
+
     return mergedConfig;
 };
 


### PR DESCRIPTION
Add org and env to cache config under 'edgemicro.global'.
Make org and env values available in the runtime.