### PR TITLE
Write and read jwk_public_keys from Redis if Synchrnizer is enabled

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -402,22 +402,41 @@ const processLoad = (config, keys, callback, useSynchronizer, redisClient) => {
             } 
         },
         function(cb) {
-            var opts = _.clone(options);
-            opts['url'] = config.edge_config.jwk_public_keys || null;
-            opts = enableTLS(config, opts);
-            request.get(opts, function(err, response, body) {
-                if (response && response.statusCode === 200) {
-                    _loadStatus('jwk_public_keys', opts['url'],
-                        err, response, body, cb);
-                } else {
-                    response = {};
-                    response.statusCode = 200;
-                    body = null;
-                    err = null;
-                    _loadStatus('jwk_public_keys', opts['url'],
-                        null, response, body, cb);
-                }
-            });
+            if (useSynchronizer || !config.edge_config.redisBasedConfigCache) {
+                var opts = _.clone(options);
+                opts['url'] = config.edge_config.jwk_public_keys || null;
+                opts = enableTLS(config, opts);
+                request.get(opts, function(err, response, body) {
+                    if(useSynchronizer && !err && response && response.statusCode === 200) {
+                        saveConfigToRedis(redisClient, globalOptions, config.edge_config.jwk_public_keys, body, 'jwk_public_keys', (err)=>{
+                            if ( err ) {
+                                writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP}, 'error saving data to redis from %s', config.edge_config.jwk_public_keys, err);
+                                return;
+                            }
+                            writeConsoleLog('info',{component: CONSOLE_LOG_TAG_COMP}, 'Saved data to redis from %s', config.edge_config.jwk_public_keys);
+                        });
+                    }
+                    if (!config.edge_config.redisBasedConfigCache) {
+                        if (response && response.statusCode === 200) {
+                            _loadStatus('jwk_public_keys', opts['url'],
+                                err, response, body, cb);
+                        } else {
+                            response = {};
+                            response.statusCode = 200;
+                            body = null;
+                            err = null;
+                            _loadStatus('jwk_public_keys', opts['url'],
+                                null, response, body, cb);
+                        }
+                    }
+                });
+            }
+            if (config.edge_config.redisBasedConfigCache === true) { //retrieve info from redis db
+                getConfigFromRedis(redisClient, globalOptions, config.edge_config.jwk_public_keys, 'jwk_public_keys', function(err, body){
+                    const response =  err ? null : { statusCode: 200, statusMessage: 'Downloaded from redis' };
+                    _loadStatus('jwk_public_keys', config.edgemicro.redisHost, err, response, body, cb);
+                });
+            } 
         }
     ], function(err, results) {
         debug('error %s, proxies %s, products %s, jwt_public_key %s', err,


### PR DESCRIPTION
This pull request is to fix issue #92 which does not write and read `jwk_public_keys` configuration from Redis if Synchronizer is enabled. Thanks!