### PR TITLE
 169810710 Handle caching of key and secret correctly

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -190,7 +190,6 @@ function loadConfiguration(thisconfig, keys, callback) {
 
             const mergedConfig = _merge(config, _mapEdgeProxies(proxies), _mapEdgeProducts(products, config));
             proxy_validator.validate(mergedConfig);
-            _mergeKeys(mergedConfig, keys); // merge keys before sending to edge micro
             callback(null, mergedConfig);
         } else {
 
@@ -212,7 +211,6 @@ function loadConfiguration(thisconfig, keys, callback) {
             
             if (mergedConfig) {
                 writeConsoleLog('info',{component: CONSOLE_LOG_TAG_COMP},'loaded cached config from', target);
-                _mergeKeys(mergedConfig, keys); // merge keys before sending to edge micro
                 callback(null, mergedConfig);
             } else {
                 writeConsoleLog('error',{component: CONSOLE_LOG_TAG_COMP},'fatal:',
@@ -590,31 +588,6 @@ const _loadStatus = function(message, url, err, response, body, cb) {
         cb(new Error(response.statusMessage), body);
     } else {
         cb(err, body);
-    }
-}
-
-/**
- * merge downloaded config with keys
- * @param mergedConfig
- * @param keys
- * @private
- */
-function _mergeKeys(mergedConfig, keys) {
-    assert(keys.key, 'key is missing');
-    assert(keys.secret, 'secret is missing');
-    // copy keys to analytics section
-    if (!mergedConfig.analytics) {
-        mergedConfig.analytics = {};
-    }
-    mergedConfig.analytics.key = keys.key;
-    mergedConfig.analytics.secret = keys.secret;
-    // copy keys to quota section
-    if (mergedConfig.quota) {
-        Object.keys(mergedConfig.quota).forEach(function(name) {
-            const quota = mergedConfig.quota[name];
-            quota.key = keys.key;
-            quota.secret = keys.secret;
-        });
     }
 }
 


### PR DESCRIPTION
 Remove _mergeKeys function and its calls with the mergedConfig to prevent saving key and secret in the cache config file