### PR TITLE
170708621 new config for analytics plugin

### DIFF
--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -5,7 +5,7 @@ var url = require('url');
 const EnvTagsReplacer = require('./env-tags-replacer');
 const envTagsReplacer = new EnvTagsReplacer();
 
-module.exports.validate = function validate(configObject) {
+module.exports.validate = function validate(configObject, options={}) {
   assert(configObject, 'config is not defined');
   let config = envTagsReplacer.replaceEnvTags(configObject);
   if (!process.env.EDGEMICRO_LOCAL && !process.env.EDGEMICRO_LOCAL_PROXY) {
@@ -169,18 +169,23 @@ module.exports.validate = function validate(configObject) {
     var allow_message = 'invalid value for config.quota.allow: ' + config.quota.allow;
     assert(+config.quota.allow > 0, allow_message);
   }
-  if (config.analytics) {
-    if (config.analytics.bufferSize) {
-      assert(typeof config.analytics.bufferSize === 'number', 'config.analytics.bufferSize is not a number');
-      assert(+config.analytics.bufferSize > 0, 'config.analytics.bufferSize is invalid');
-    }
-    if (config.analytics.flushInterval) {
-      assert(typeof config.analytics.flushInterval === 'number', 'config.analytics.flushInterval is not a number');
-      assert(+config.analytics.flushInterval > 0, 'config.analytics.flushInterval is invalid');
-    }
-    if (config.analytics.batchSize) {
-      assert(typeof config.analytics.batchSize === 'number', 'config.analytics.batchSize is not a number');
-      assert(+config.analytics.batchSize > 0, 'config.analytics.batchSize is invalid');
+  if (config.edgemicro.hasOwnProperty('enableAnalytics')) {
+    assert(typeof config.edgemicro.enableAnalytics === 'boolean', 'config.edgemicro.enableAnalytics is not a boolean');
+  }
+  if(!config.edgemicro.hasOwnProperty('enableAnalytics') || config.edgemicro.enableAnalytics === true || options.metrics === true){
+    if (config.analytics) {
+      if (config.analytics.bufferSize) {
+        assert(typeof config.analytics.bufferSize === 'number', 'config.analytics.bufferSize is not a number');
+        assert(+config.analytics.bufferSize > 0, 'config.analytics.bufferSize is invalid');
+      }
+      if (config.analytics.flushInterval) {
+        assert(typeof config.analytics.flushInterval === 'number', 'config.analytics.flushInterval is not a number');
+        assert(+config.analytics.flushInterval > 0, 'config.analytics.flushInterval is invalid');
+      }
+      if (config.analytics.batchSize) {
+        assert(typeof config.analytics.batchSize === 'number', 'config.analytics.batchSize is not a number');
+        assert(+config.analytics.batchSize > 0, 'config.analytics.batchSize is invalid');
+      }
     }
   }
   if (config.spikearrest) {

--- a/lib/network.js
+++ b/lib/network.js
@@ -83,7 +83,7 @@ Loader.prototype.get = function(options, callback) {
             uri: "http://localhost"
         };
         
-        default_config_validator.validate(config);
+        default_config_validator.validate(config, globalOptions);
 
         const cache = _.merge({}, config, proxies);
 
@@ -144,7 +144,7 @@ function writeConfig(source, body) {
 
 function loadConfiguration(thisconfig, keys, callback, envReplacedConfig) {
 
-    default_config_validator.validate(thisconfig);
+    default_config_validator.validate(thisconfig, globalOptions);
 
     const err = _validateUrls(envReplacedConfig);
     if (err) {
@@ -198,7 +198,7 @@ function loadConfiguration(thisconfig, keys, callback, envReplacedConfig) {
             }
 
             const mergedConfig = _merge(config, _mapEdgeProxies(proxies), _mapEdgeProducts(products, config));
-            proxy_validator.validate(mergedConfig);
+            proxy_validator.validate(mergedConfig, globalOptions);
             callback(null, mergedConfig);
         } else {
 

--- a/lib/proxy-validator.js
+++ b/lib/proxy-validator.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 const EnvTagsReplacer = require('./env-tags-replacer');
 const envTagsReplacer = new EnvTagsReplacer();
 
-module.exports.validate = function validate(configObject) {
+module.exports.validate = function validate(configObject, options) {
   assert(configObject, 'config is not defined');
   const config = envTagsReplacer.replaceEnvTags(configObject, { disableLogs: true });
   assert(config.proxies, 'config.proxies is not defined');
@@ -18,15 +18,17 @@ module.exports.validate = function validate(configObject) {
     assert(proxy.max_connections, 'config.proxy[' + index + '].max_connections is not defined');
     assert(typeof proxy.max_connections === 'number', 'config.proxy[' + index + '].max_connections is not a number');
   });
-  if (config.analytics) {
-    assert(config.analytics.uri, 'config.analytics.uri is not defined');
-    assert(typeof config.analytics.uri === 'string', 'config.analytics.uri is not a string');
-    assert(config.analytics.proxy, 'config.analytics.proxy is not defined');
-    assert(config.analytics.proxy === 'dummy', 'config.analytics.proxy is not "dummy"');
-    assert(config.analytics.source, 'config.analytics.source is not defined');
-    assert(config.analytics.source === 'microgateway', 'config.analytics.source is not "microgateway"');
-    assert(config.analytics.proxy_revision, 'config.analytics.proxy_revision is not defined');
-    assert(typeof config.analytics.proxy_revision === 'number', 'config.analytics.proxy_revision is not a number');
+  if(!config.edgemicro.hasOwnProperty('enableAnalytics') || config.edgemicro.enableAnalytics === true || options.metrics === true){
+    if (config.analytics) {
+      assert(config.analytics.uri, 'config.analytics.uri is not defined');
+      assert(typeof config.analytics.uri === 'string', 'config.analytics.uri is not a string');
+      assert(config.analytics.proxy, 'config.analytics.proxy is not defined');
+      assert(config.analytics.proxy === 'dummy', 'config.analytics.proxy is not "dummy"');
+      assert(config.analytics.source, 'config.analytics.source is not defined');
+      assert(config.analytics.source === 'microgateway', 'config.analytics.source is not "microgateway"');
+      assert(config.analytics.proxy_revision, 'config.analytics.proxy_revision is not defined');
+      assert(typeof config.analytics.proxy_revision === 'number', 'config.analytics.proxy_revision is not a number');
+    }
   }
   if (config.oauth) {
     assert(typeof config.oauth.public_key === 'string', 'config.oauth.public_key is not defined');


### PR DESCRIPTION
Add validations to verify analytics options in config.yaml file.
  Throw assertion error if edgemicro.enableAnalytics is not of type boolean
  Validate analytics parameters based on enableAnalytics and metrics options