### PR TITLE
192416584 Make permission for log file configurable

### DIFF
--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -120,6 +120,9 @@ module.exports.validate = function validate(configObject, options={}) {
   if (config.edgemicro.logging.to_console){
     assert(typeof config.edgemicro.logging.to_console === 'boolean', 'config.edgemicro.logging.to_console should be a boolean');
   }
+  if (config.edgemicro.logging.disableStrictLogFile){
+    assert(typeof config.edgemicro.logging.disableStrictLogFile === 'boolean', 'config.edgemicro.logging.disableStrictLogFile should be a boolean');
+  }
   if (config.edgemicro.plugins) {
     if(config.edgemicro.plugins.sequence){
       assert(Array.isArray(config.edgemicro.plugins.sequence), 'config.edgemicro.plugins.sequence is not an array');


### PR DESCRIPTION
  Added new config “disableStrictLogFile” under edgemicro.logging config to support change in permission of log file.
  Added validation for the config to accept only boolean values