### PR TITLE
198592863 Add validation for access control plugin

### DIFF
--- a/lib/default-validator.js
+++ b/lib/default-validator.js
@@ -252,6 +252,7 @@ module.exports.validate = function validate(configObject, options={}) {
   if (config.accesscontrol) {
     if(config.accesscontrol.noRuleMatchAction){
       assert(typeof config.accesscontrol.noRuleMatchAction === 'string', 'config.accesscontrol.noRuleMatchAction is not an string');
+      assert(config.accesscontrol.noRuleMatchAction === 'allow' || config.accesscontrol.noRuleMatchAction === 'deny', 'config.accesscontrol.noRuleMatchAction should be either allow | deny');
     }    
   }
   


### PR DESCRIPTION
  Added assertion check for noRuleMatchAction config of accesscontrol plugin
  to allow only "allow" or "deny" string values